### PR TITLE
Add warning modal for switching from custom to another allocation method

### DIFF
--- a/src/components/metrics-editor/change-allocation-dialog.tsx
+++ b/src/components/metrics-editor/change-allocation-dialog.tsx
@@ -1,0 +1,74 @@
+'use client';
+
+import { type ComponentProps } from 'react';
+import { useAccount } from 'wagmi';
+
+import {
+  DistributionMethod,
+  useDistributionMethodFromLocalStorage,
+  useDistributionMethod,
+  saveDistributionMethodToLocalStorage,
+} from '@/hooks/useBallotRound5';
+
+import { Button } from '../ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '../ui/dialog';
+
+export function ChangeAllocationMethodDialog({
+  isOpen,
+  onOpenChange,
+  distributionMethod,
+}: ComponentProps<typeof Dialog> & {
+  isOpen: boolean;
+  distributionMethod: DistributionMethod;
+}) {
+  const { address } = useAccount();
+  const { mutate: saveDistributionMethod } = useDistributionMethod();
+  const { refetch } =
+    useDistributionMethodFromLocalStorage();
+
+  return (
+    <Dialog open={isOpen} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-[458px]">
+        <DialogHeader>
+          <DialogTitle>
+            Are you sure you want to select this allocation method?
+          </DialogTitle>
+          <DialogDescription>
+            You&apos;ll lose any customizations you&apos;ve made.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="flex flex-col gap-2">
+          <Button
+            variant="destructive"
+            onClick={() => {
+              saveDistributionMethodToLocalStorage(
+                distributionMethod,
+                address
+              );
+              if (
+                distributionMethod === DistributionMethod.IMPACT_GROUPS ||
+                distributionMethod === DistributionMethod.TOP_TO_BOTTOM ||
+                distributionMethod === DistributionMethod.TOP_WEIGHTED
+              ) {
+                saveDistributionMethod(distributionMethod);
+              }
+              refetch();
+              onOpenChange?.(false);
+            }}
+          >
+            Select allocation method
+          </Button>
+          <Button variant="outline" onClick={() => onOpenChange?.(false)}>
+            Cancel
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/metrics-editor/index.tsx
+++ b/src/components/metrics-editor/index.tsx
@@ -22,6 +22,8 @@ import { BallotFilter } from '../ballot/ballot-filter';
 import { Card } from '../ui/card';
 
 import { ResetButton } from './reset-button';
+import { useState } from 'react';
+import { ChangeAllocationMethodDialog } from './change-allocation-dialog';
 
 export function BlueCircleCheckIcon() {
   return (
@@ -45,6 +47,9 @@ export function MetricsEditor({ budget }: { budget: number }) {
   const { mutate: saveDistributionMethod } = useDistributionMethod();
   const { data: distributionMethod, refetch } =
     useDistributionMethodFromLocalStorage();
+
+  const [isOpen, setOpen] = useState(false);
+  const [selectedMethod, setSelectedMethod] = useState<DistributionMethod>(DistributionMethod.CUSTOM);
 
   const allocationMethods = [
     {
@@ -119,6 +124,14 @@ export function MetricsEditor({ budget }: { budget: number }) {
               'border-2 border-[#BCBFCD]': distributionMethod === method.method,
             })}
             onClick={() => {
+              if (
+                distributionMethod === DistributionMethod.CUSTOM &&
+                method.method !== DistributionMethod.CUSTOM
+              ) {
+                setSelectedMethod(method.method);
+                setOpen(true);
+                return;
+              }
               saveDistributionMethodToLocalStorage(
                 method.method as DistributionMethod,
                 address
@@ -172,7 +185,11 @@ export function MetricsEditor({ budget }: { budget: number }) {
           </Card>
         ))}
       </div>
-      {/* ^^This sections is a work in progress^^ */}
+      <ChangeAllocationMethodDialog
+        isOpen={isOpen}
+        onOpenChange={setOpen}
+        distributionMethod={selectedMethod}
+      />
     </div>
   );
 }


### PR DESCRIPTION
This is a scope addition that displays a warning modal to let user know that any customizations they made to their ballot will be lost if they select one of the other allocation methods.